### PR TITLE
ci: avoid referencing secrets directly in if expressions

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -41,6 +41,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check Keystore presence
+        id: keystore_check
+        run: |
+          if [ -n "${{ secrets.KEYSTORE_BASE64 }}" ]; then
+            echo "keystore_present=true" >> $GITHUB_OUTPUT
+          else
+            echo "keystore_present=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build web app
         run: npm run build
 
@@ -120,14 +129,14 @@ jobs:
           retention-days: 7
 
       - name: Decode Keystore
-        if: ${{ secrets.KEYSTORE_BASE64 != '' }}
+        if: ${{ steps.keystore_check.outputs.keystore_present == 'true' }}
         run: |
           echo "🔐 Decoding keystore..."
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > android/app/release.keystore
           echo "✅ Keystore decoded successfully"
 
       - name: Build Release APK (Signed)
-        if: ${{ secrets.KEYSTORE_BASE64 != '' }}
+        if: ${{ steps.keystore_check.outputs.keystore_present == 'true' }}
         env:
           KEYSTORE_FILE: release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -140,7 +149,7 @@ jobs:
           echo "✅ Signed APK built successfully"
 
       - name: Build Release APK (Unsigned fallback)
-        if: ${{ secrets.KEYSTORE_BASE64 == '' }}
+        if: ${{ steps.keystore_check.outputs.keystore_present == 'false' }}
         run: |
           cd android
           echo "⚠️ Building unsigned release APK (no keystore configured)..."
@@ -156,7 +165,7 @@ jobs:
 
       - name: Upload Release APK (Signed)
         uses: actions/upload-artifact@v4
-        if: ${{ secrets.KEYSTORE_BASE64 != '' && success() }}
+        if: ${{ steps.keystore_check.outputs.keystore_present == 'true' && success() }}
         with:
           name: byd-stats-release-signed-${{ github.sha }}
           path: android/app/build/outputs/apk/release/app-release.apk
@@ -164,7 +173,7 @@ jobs:
 
       - name: Upload Release APK (Unsigned)
         uses: actions/upload-artifact@v4
-        if: ${{ secrets.KEYSTORE_BASE64 == '' && success() }}
+        if: ${{ steps.keystore_check.outputs.keystore_present == 'false' && success() }}
         with:
           name: byd-stats-release-unsigned-${{ github.sha }}
           path: android/app/build/outputs/apk/release/app-release-unsigned.apk
@@ -172,7 +181,7 @@ jobs:
         continue-on-error: true
 
       - name: Create Release (with signed APK)
-        if: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.KEYSTORE_BASE64 != '' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && steps.keystore_check.outputs.keystore_present == 'true' }}
         uses: softprops/action-gh-release@v1
         with:
           files: |
@@ -185,7 +194,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release (without signed APK)
-        if: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.KEYSTORE_BASE64 == '' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && steps.keystore_check.outputs.keystore_present == 'false' }}
         uses: softprops/action-gh-release@v1
         with:
           files: |

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -38,6 +38,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check Keystore presence
+        id: keystore_check
+        run: |
+          if [ -n "${{ secrets.KEYSTORE_BASE64 }}" ]; then
+            echo "keystore_present=true" >> $GITHUB_OUTPUT
+          else
+            echo "keystore_present=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build web app
         run: npm run build
 
@@ -93,14 +102,14 @@ jobs:
           ./gradlew assembleDebug --stacktrace
 
       - name: Decode Keystore
-        if: ${{ secrets.KEYSTORE_BASE64 != '' }}
+        if: ${{ steps.keystore_check.outputs.keystore_present == 'true' }}
         run: |
           echo "🔐 Decoding keystore..."
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > android/app/release.keystore
           echo "✅ Keystore decoded successfully"
 
       - name: Build Release APK (Signed if keystore present)
-        if: github.event.inputs.build_type == 'release' || github.event.inputs.build_type == 'both'
+        if: ${{ (github.event.inputs.build_type == 'release' || github.event.inputs.build_type == 'both') && steps.keystore_check.outputs.keystore_present == 'true' }}
         env:
           KEYSTORE_FILE: release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -125,7 +134,7 @@ jobs:
           retention-days: 90
 
       - name: Upload Release APK (Signed)
-        if: ${{ (github.event.inputs.build_type == 'release' || github.event.inputs.build_type == 'both') && secrets.KEYSTORE_BASE64 != '' }}
+        if: ${{ (github.event.inputs.build_type == 'release' || github.event.inputs.build_type == 'both') && steps.keystore_check.outputs.keystore_present == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: byd-stats-release-signed-${{ steps.date.outputs.date }}


### PR DESCRIPTION
Replace step-level/if expressions that directly reference secrets with a small  step that sets an output. This prevents workflow validation errors when expressions referencing  are evaluated. Applies to  and .