### PR TITLE
fix: implement SocialLogin interface in MainActivity to allow scopes

### DIFF
--- a/android/app/src/main/java/com/bydstats/app/MainActivity.java
+++ b/android/app/src/main/java/com/bydstats/app/MainActivity.java
@@ -10,8 +10,11 @@ import android.webkit.WebView;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 import com.getcapacitor.BridgeActivity;
+import ee.forgr.capacitor.social.login.ModifiedMainActivityForSocialLoginPlugin;
 
-public class MainActivity extends BridgeActivity {
+
+public class MainActivity extends BridgeActivity implements ModifiedMainActivityForSocialLoginPlugin {
+
 
     private void configureStatusBar() {
         Window window = getWindow();
@@ -73,4 +76,8 @@ public class MainActivity extends BridgeActivity {
         // Re-apply status bar configuration in case something overrode it
         configureStatusBar();
     }
+
+    @Override
+    public void IHaveModifiedTheMainActivityForTheUseWithSocialLoginPlugin() {}
 }
+

--- a/src/components/modals/SettingsModal.jsx
+++ b/src/components/modals/SettingsModal.jsx
@@ -123,10 +123,7 @@ const SettingsModal = ({ isOpen, onClose, settings, onSettingsChange, googleSync
 
                             {!googleSync.isAuthenticated ? (
                                 <button
-                                    onClick={() => {
-                                        alert('Login button clicked! Platform: ' + (window.Capacitor?.isNativePlatform ? 'Native' : 'Web'));
-                                        googleSync.login();
-                                    }}
+                                    onClick={googleSync.login}
                                     className="w-full flex items-center justify-center gap-2 bg-white dark:bg-slate-700 text-slate-700 dark:text-white border border-slate-300 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-600 font-medium rounded-xl px-4 py-2.5 transition-colors"
                                 >
                                     <svg className="w-5 h-5" viewBox="0 0 24 24">

--- a/src/hooks/useGoogleSync.js
+++ b/src/hooks/useGoogleSync.js
@@ -195,8 +195,7 @@ export function useGoogleSync(localTrips, setLocalTrips, settings, setSettings) 
                 const result = await SocialLogin.login({
                     provider: 'google',
                     options: {
-                        // Note: Custom scopes like drive.appdata require MainActivity modifications
-                        // For now, using default scopes (email, profile) which work without modifications
+                        scopes: ['email', 'profile', 'https://www.googleapis.com/auth/drive.appdata']
                     }
                 });
                 console.log("Native Login Success:", JSON.stringify(result));


### PR DESCRIPTION
- Implement ModifiedMainActivityForSocialLoginPlugin in MainActivity.java
- Restore drive.appdata scope in useGoogleSync.js
- Remove debug alert from SettingsModal.jsx
- Final fix for 'You CANNOT use scopes without modifying the main activity' error