### PR TITLE
fix: use debug signing as fallback for release build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,6 +34,8 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             if (System.getenv('KEYSTORE_FILE')) {
                 signingConfig signingConfigs.release
+            } else {
+                signingConfig signingConfigs.debug
             }
         }
     }


### PR DESCRIPTION
This allows release APKs built in environments without custom keys (like GitHub) to be signed and work with Google Login using the same SHA-1 fingerprint.