### PR TITLE
fix: restore drive scope and ensure GitHub Actions captures the signe…

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -178,12 +178,14 @@ jobs:
           path: android/app/build/outputs/apk/release/app-release.apk
           retention-days: 30
 
-      - name: Upload Release APK (Unsigned)
+      - name: Upload Release APK (Generic)
         uses: actions/upload-artifact@v4
-        if: steps.keystore_check.outputs.keystore_present == 'false' && success()
+        if: steps.keystore_check.outputs.keystore_present == 'false'
         with:
           name: byd-stats-release-unsigned-${{ github.sha }}
-          path: android/app/build/outputs/apk/release/app-release-unsigned.apk
+          path: |
+            android/app/build/outputs/apk/release/app-release-unsigned.apk
+            android/app/build/outputs/apk/release/app-release.apk
           retention-days: 30
         continue-on-error: true
 

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -148,12 +148,14 @@ jobs:
           path: android/app/build/outputs/apk/release/app-release.apk
           retention-days: 90
 
-      - name: Upload Release APK (Unsigned fallback)
+      - name: Upload Release APK (Generic)
         if: (github.event.inputs.build_type == 'release' || github.event.inputs.build_type == 'both')
         uses: actions/upload-artifact@v4
         with:
           name: byd-stats-release-unsigned-${{ steps.date.outputs.date }}
-          path: android/app/build/outputs/apk/release/app-release-unsigned.apk
+          path: |
+             android/app/build/outputs/apk/release/app-release-unsigned.apk
+             android/app/build/outputs/apk/release/app-release.apk
           retention-days: 90
         continue-on-error: true
 

--- a/src/hooks/useGoogleSync.js
+++ b/src/hooks/useGoogleSync.js
@@ -195,7 +195,7 @@ export function useGoogleSync(localTrips, setLocalTrips, settings, setSettings) 
                 const result = await SocialLogin.login({
                     provider: 'google',
                     options: {
-                        scopes: ['email', 'profile']
+                        scopes: ['email', 'profile', 'https://www.googleapis.com/auth/drive.appdata']
                     }
                 });
                 console.log("Native Login Success:", JSON.stringify(result));


### PR DESCRIPTION
…d release APK fallback

- Reverted scope removal in useGoogleSync.js (drive.appdata is needed)
- Updated workflows to capture app-release.apk (which is generated when using debug signing fallback) instead of just unsigned apk