### PR TITLE
fix: Fine-tune spacing and heights for all modes across tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -267,10 +267,10 @@ export default function BYDStatsAnalyzer() {
   const smallChartHeight = isFullscreenBYD ? 271 : (isCompact ? 270 : 326);
 
   // Charts for Patrones (viajes por día): need more height
-  // Fullscreen BYD: 286px (+5px more)
-  // Compact: 277px (+2px more)
+  // Fullscreen BYD: 289px (+3px more)
+  // Compact: 278px (+1px more)
   // Normal: 336px (+10px from smallChart base)
-  const patternsChartHeight = isFullscreenBYD ? 286 : (isCompact ? 277 : 336);
+  const patternsChartHeight = isFullscreenBYD ? 289 : (isCompact ? 278 : 336);
 
   // Large charts (Tendencias, Eficiencia): originally 350/450
   // Fullscreen BYD: 395px (reduced 55px from 450)
@@ -278,18 +278,18 @@ export default function BYDStatsAnalyzer() {
   const largeChartHeight = isFullscreenBYD ? 395 : (isCompact ? 345 : 450);
 
   // Spacing adjustments for different modes
-  // Overview/Resumen spacing (vertical mode): compact +1px, normal +2px
-  const overviewSpacingVertical = isCompact ? 'space-y-2.5' : 'space-y-3.5 sm:space-y-5';
-  // Overview/Resumen spacing (horizontal mode): compact +1px, normal +2px
-  const overviewSpacingHorizontal = isCompact ? 'space-y-2.5' : 'space-y-5 sm:space-y-6.5';
+  // Overview/Resumen spacing (vertical mode): fullscreenBYD +2px, compact +1px, normal +2px
+  const overviewSpacingVertical = isFullscreenBYD ? 'space-y-[14px]' : (isCompact ? 'space-y-2.5' : 'space-y-3.5 sm:space-y-5');
+  // Overview/Resumen spacing (horizontal mode): fullscreenBYD +2px, compact +1px, normal +2px
+  const overviewSpacingHorizontal = isFullscreenBYD ? 'space-y-[22px]' : (isCompact ? 'space-y-2.5' : 'space-y-5 sm:space-y-6.5');
 
-  // Patterns spacing: fullscreenBYD +10px, normal +5px
-  const patternsSpacing = isFullscreenBYD ? 'space-y-[21px]' : (isCompact ? 'space-y-3' : 'space-y-5');
+  // Patterns spacing: fullscreenBYD +10px, normal +7px (was +5px, now +2px more)
+  const patternsSpacing = isFullscreenBYD ? 'space-y-[21px]' : (isCompact ? 'space-y-3' : 'space-y-[22px]');
 
   // Records list item padding
   const recordsItemPadding = isFullscreenBYD ? 'py-0.5' : (isCompact ? 'py-[1px]' : 'py-1.5');
   const recordsItemPaddingHorizontal = isFullscreenBYD ? 'py-1' : (isCompact ? 'py-[1.5px]' : 'py-2');
-  const recordsListHeightHorizontal = isFullscreenBYD ? 'h-[400px]' : (isCompact ? 'h-[345px]' : 'h-[450px]');
+  const recordsListHeightHorizontal = isFullscreenBYD ? 'h-[397px]' : (isCompact ? 'h-[345px]' : 'h-[450px]');
 
   // DEBUG: Log to verify mode detection
   console.log('[DEBUG] Mode detection:', {


### PR DESCRIPTION
Normal mode:
- Patterns: increase vertical spacing by 2px (space-y-[22px])

Compact mode:
- Patterns: increase chart height by 1px (278px)

FullscreenBYD mode (1280x720):
- Records: reduce list height by 3px (h-[397px])
- Patterns: increase chart height by 3px (289px)
- Overview/Resumen: increase vertical spacing by 2px (space-y-[14px] / space-y-[22px])