### PR TITLE
feat: Mejoras exclusivas para modo compacto

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -265,19 +265,19 @@ export default function BYDStatsAnalyzer() {
 
   // Small charts for Resumen: originally 275/326
   // Fullscreen BYD: 271px (reduced 55px from 326)
-  // Compact: 270px (reduced 5px from 275)
-  const smallChartHeight = isFullscreenBYD ? 271 : (isCompact ? 270 : 326);
+  // Compact: 295px (270 + 25px extra)
+  const smallChartHeight = isFullscreenBYD ? 271 : (isCompact ? 295 : 326);
 
   // Charts for Patrones (viajes por día): need more height
   // Fullscreen BYD: 289px (+3px more)
-  // Compact: 278px (+1px more)
+  // Compact: 303px (278 + 25px extra)
   // Normal: 336px (+10px from smallChart base)
-  const patternsChartHeight = isFullscreenBYD ? 289 : (isCompact ? 278 : 336);
+  const patternsChartHeight = isFullscreenBYD ? 289 : (isCompact ? 303 : 336);
 
   // Large charts (Tendencias, Eficiencia): originally 350/450
   // Fullscreen BYD: 395px (reduced 55px from 450)
-  // Compact: 345px (reduced 5px from 350)
-  const largeChartHeight = isFullscreenBYD ? 395 : (isCompact ? 345 : 450);
+  // Compact: 370px (345 + 25px extra)
+  const largeChartHeight = isFullscreenBYD ? 395 : (isCompact ? 370 : 450);
 
   // Spacing adjustments for different modes
   // Overview/Resumen spacing (vertical mode): fullscreenBYD +2px, compact +1px, normal +2px
@@ -291,7 +291,7 @@ export default function BYDStatsAnalyzer() {
   // Records list item padding
   const recordsItemPadding = isFullscreenBYD ? 'py-0.5' : (isCompact ? 'py-[1px]' : 'py-1.5');
   const recordsItemPaddingHorizontal = isFullscreenBYD ? 'py-1' : (isCompact ? 'py-[1.5px]' : 'py-2');
-  const recordsListHeightHorizontal = isFullscreenBYD ? 'h-[397px]' : (isCompact ? 'h-[345px]' : 'h-[450px]');
+  const recordsListHeightHorizontal = isFullscreenBYD ? 'h-[397px]' : (isCompact ? 'h-[370px]' : 'h-[450px]');
 
   // DEBUG: Log to verify mode detection
   console.log('[DEBUG] Mode detection:', {
@@ -2816,7 +2816,7 @@ export default function BYDStatsAnalyzer() {
           )}
         </div>
       </div >
-      <PWAManager layoutMode={layoutMode} />
+      <PWAManager layoutMode={layoutMode} isCompact={isCompact} />
     </div >
   );
 }

--- a/src/components/PWAManager.jsx
+++ b/src/components/PWAManager.jsx
@@ -23,8 +23,9 @@ const RefreshCw = ({ className }) => (
  * PWA Manager Component
  * Handles PWA installation prompt, exit button, and update notifications
  * @param {string} layoutMode - 'horizontal' or 'vertical' from parent
+ * @param {boolean} isCompact - Whether compact mode is active
  */
-export default function PWAManager({ layoutMode = 'vertical' }) {
+export default function PWAManager({ layoutMode = 'vertical', isCompact = false }) {
     const { t } = useTranslation();
     const [deferredPrompt, setDeferredPrompt] = useState(null);
     const [showInstallBanner, setShowInstallBanner] = useState(false);
@@ -33,8 +34,8 @@ export default function PWAManager({ layoutMode = 'vertical' }) {
     const [showUpdateBanner, setShowUpdateBanner] = useState(false);
     const [waitingWorker, setWaitingWorker] = useState(null);
 
-    // Exit button only shows in horizontal + standalone mode
-    const showExitButton = isStandalone && layoutMode === 'horizontal';
+    // Exit button only shows in horizontal + standalone mode, but NOT in compact mode
+    const showExitButton = isStandalone && layoutMode === 'horizontal' && !isCompact;
 
     // Check if running as PWA
     useEffect(() => {

--- a/src/components/modals/TripDetailModal.jsx
+++ b/src/components/modals/TripDetailModal.jsx
@@ -45,64 +45,67 @@ const TripDetailModal = ({ isOpen, onClose, trip, allTrips, summary, settings })
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4" onClick={onClose}>
             <div className="absolute inset-0 bg-black/50 backdrop-blur-sm"></div>
             <div
-                className="relative bg-white dark:bg-slate-800 rounded-2xl p-6 max-w-lg w-full border border-slate-200 dark:border-slate-700 max-h-[90vh] overflow-y-auto"
+                className="relative bg-white dark:bg-slate-800 rounded-2xl p-5 max-w-lg w-full border border-slate-200 dark:border-slate-700"
                 onClick={(e) => e.stopPropagation()}
             >
+                {/* Header con título, fecha y score en la misma fila */}
                 <div className="flex items-center justify-between mb-4">
-                    <div>
-                        <h2 className="text-xl font-bold text-slate-900 dark:text-white">{t('tripDetail.title')}</h2>
-                        <p className="text-sm text-slate-600 dark:text-slate-400">
-                            {formatDate(trip.date)} · {formatTime(trip.start_timestamp)}
-                        </p>
+                    <div className="flex items-center gap-4">
+                        <div>
+                            <h2 className="text-lg font-bold text-slate-900 dark:text-white">{t('tripDetail.title')}</h2>
+                            <p className="text-sm text-slate-600 dark:text-slate-400">
+                                {formatDate(trip.date)} · {formatTime(trip.start_timestamp)}
+                            </p>
+                        </div>
                     </div>
-                    <button onClick={onClose} className="text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white">
-                        <Plus className="w-6 h-6 rotate-45" />
-                    </button>
-                </div>
-
-                {/* Score prominente */}
-                <div className="text-center py-6">
-                    <p className="text-slate-600 dark:text-slate-400 text-sm mb-2">{t('tripDetail.title')}</p>
-                    <p className="text-6xl font-black" style={{ color: details.scoreColor }}>
-                        {details.score.toFixed(1)}
-                    </p>
-                    <p className="text-slate-500 dark:text-slate-400 text-sm mt-1">/ 10</p>
+                    <div className="flex items-center gap-3">
+                        {/* Score compacto */}
+                        <div className="text-right">
+                            <p className="text-3xl font-black" style={{ color: details.scoreColor }}>
+                                {details.score.toFixed(1)}
+                            </p>
+                            <p className="text-slate-500 dark:text-slate-400 text-xs">/ 10</p>
+                        </div>
+                        <button onClick={onClose} className="text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white ml-2">
+                            <Plus className="w-6 h-6 rotate-45" />
+                        </button>
+                    </div>
                 </div>
 
                 {/* Stats grid */}
-                <div className="grid grid-cols-2 gap-3 mb-4">
-                    <div className="bg-slate-100 dark:bg-slate-700/50 rounded-xl p-4 text-center">
-                        <MapPin className="w-5 h-5 mx-auto mb-1 text-red-400" />
-                        <p className="text-slate-600 dark:text-slate-400 text-xs mb-1">{t('stats.distance')}</p>
-                        <p className="text-slate-900 dark:text-white text-xl font-bold">{trip.trip?.toFixed(1)} {t('units.km')}</p>
+                <div className="grid grid-cols-2 gap-2 mb-3">
+                    <div className="bg-slate-100 dark:bg-slate-700/50 rounded-xl p-3 text-center">
+                        <MapPin className="w-4 h-4 mx-auto mb-0.5 text-red-400" />
+                        <p className="text-slate-600 dark:text-slate-400 text-xs">{t('stats.distance')}</p>
+                        <p className="text-slate-900 dark:text-white text-lg font-bold">{trip.trip?.toFixed(1)} {t('units.km')}</p>
                     </div>
-                    <div className="bg-slate-100 dark:bg-slate-700/50 rounded-xl p-4 text-center">
-                        <Clock className="w-5 h-5 mx-auto mb-1 text-amber-400" />
-                        <p className="text-slate-600 dark:text-slate-400 text-xs mb-1">{t('tripDetail.duration')}</p>
-                        <p className="text-slate-900 dark:text-white text-xl font-bold">{formatDuration(trip.duration)}</p>
+                    <div className="bg-slate-100 dark:bg-slate-700/50 rounded-xl p-3 text-center">
+                        <Clock className="w-4 h-4 mx-auto mb-0.5 text-amber-400" />
+                        <p className="text-slate-600 dark:text-slate-400 text-xs">{t('tripDetail.duration')}</p>
+                        <p className="text-slate-900 dark:text-white text-lg font-bold">{formatDuration(trip.duration)}</p>
                     </div>
-                    <div className="bg-slate-100 dark:bg-slate-700/50 rounded-xl p-4 text-center">
-                        <Zap className="w-5 h-5 mx-auto mb-1 text-cyan-400" />
-                        <p className="text-slate-600 dark:text-slate-400 text-xs mb-1">{t('tripDetail.consumption')}</p>
-                        <p className="text-slate-900 dark:text-white text-xl font-bold">{trip.electricity?.toFixed(2)} {t('units.kWh')}</p>
+                    <div className="bg-slate-100 dark:bg-slate-700/50 rounded-xl p-3 text-center">
+                        <Zap className="w-4 h-4 mx-auto mb-0.5 text-cyan-400" />
+                        <p className="text-slate-600 dark:text-slate-400 text-xs">{t('tripDetail.consumption')}</p>
+                        <p className="text-slate-900 dark:text-white text-lg font-bold">{trip.electricity?.toFixed(2)} {t('units.kWh')}</p>
                     </div>
-                    <div className="bg-slate-100 dark:bg-slate-700/50 rounded-xl p-4 text-center">
-                        <Battery className="w-5 h-5 mx-auto mb-1 text-green-400" />
-                        <p className="text-slate-600 dark:text-slate-400 text-xs mb-1">{t('stats.efficiency')}</p>
-                        <p className="text-slate-900 dark:text-white text-xl font-bold">{details.efficiency.toFixed(2)}</p>
+                    <div className="bg-slate-100 dark:bg-slate-700/50 rounded-xl p-3 text-center">
+                        <Battery className="w-4 h-4 mx-auto mb-0.5 text-green-400" />
+                        <p className="text-slate-600 dark:text-slate-400 text-xs">{t('stats.efficiency')}</p>
+                        <p className="text-slate-900 dark:text-white text-lg font-bold">{details.efficiency.toFixed(2)}</p>
                         <p className="text-slate-500 dark:text-slate-400 text-[10px]">{t('units.kWh100km')}</p>
                     </div>
                 </div>
 
                 {/* Speed */}
                 {trip.duration > 0 && (
-                    <div className="bg-slate-100 dark:bg-slate-700/50 rounded-xl p-4 mb-4">
+                    <div className="bg-slate-100 dark:bg-slate-700/50 rounded-xl p-3 mb-3">
                         <div className="flex items-center justify-between">
                             <div className="flex items-center gap-2">
-                                <TrendingUp className="w-5 h-5 text-blue-400" />
+                                <TrendingUp className="w-4 h-4 text-blue-400" />
                                 <span className="text-slate-600 dark:text-slate-400 text-sm">{t('stats.avgSpeed')}</span>
                             </div>
-                            <p className="text-slate-900 dark:text-white text-xl font-bold">
+                            <p className="text-slate-900 dark:text-white text-lg font-bold">
                                 {(trip.trip / (trip.duration / 3600)).toFixed(1)} {t('units.kmh')}
                             </p>
                         </div>
@@ -111,16 +114,17 @@ const TripDetailModal = ({ isOpen, onClose, trip, allTrips, summary, settings })
 
                 {/* Regeneration if available */}
                 {trip.regeneration !== undefined && trip.regeneration !== null && (
-                    <div className="bg-slate-100 dark:bg-slate-700/50 rounded-xl p-4 mb-4">
-                        <p className="text-slate-600 dark:text-slate-400 text-sm mb-1">{t('tripDetail.energyRecovered')}</p>
-                        <p className="text-green-400 text-2xl font-bold">{trip.regeneration?.toFixed(2)} {t('units.kWh')}</p>
+                    <div className="bg-slate-100 dark:bg-slate-700/50 rounded-xl p-3 mb-3">
+                        <div className="flex items-center justify-between">
+                            <span className="text-slate-600 dark:text-slate-400 text-sm">{t('tripDetail.energyRecovered')}</span>
+                            <span className="text-green-400 text-lg font-bold">{trip.regeneration?.toFixed(2)} {t('units.kWh')}</span>
+                        </div>
                     </div>
                 )}
 
-                {/* Comparison and percentile */}
-                <div className="bg-slate-100 dark:bg-slate-700/50 rounded-xl p-4">
-                    <p className="text-slate-600 dark:text-slate-400 text-sm mb-3">{t('tripDetail.analysis')}</p>
-                    <div className="space-y-2">
+                {/* Comparison and percentile - sin título "análisis" */}
+                <div className="bg-slate-100 dark:bg-slate-700/50 rounded-xl p-3">
+                    <div className="space-y-1.5">
                         <div className="flex items-center justify-between">
                             <span className="text-slate-500 dark:text-slate-400 text-sm">{t('tripDetail.comparedToAvg')}</span>
                             <span className={`font-bold ${details.comparisonPercent < 0 ? 'text-green-400' : 'text-red-400'}`}>


### PR DESCRIPTION
- Ocultar botón "Salir" en modo compacto (solo visible en horizontal no compacto)
- Aumentar 25px la altura de todos los gráficos en modo compacto
- Reorganizar modal "Detalles del viaje" para evitar scroll:
  - Título, fecha y score en la misma fila
  - Eliminar texto "análisis" innecesario
  - Reducir paddings y espaciados