### PR TITLE
fix: include charges data in Google Drive cloud sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "byd-stats",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "byd-stats",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@capacitor/android": "^8.0.0",
         "@capacitor/app": "^8.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -156,7 +156,8 @@ export default function BYDStatsAnalyzer() {
     charges,
     addCharge,
     addMultipleCharges,
-    deleteCharge
+    deleteCharge,
+    replaceCharges
   } = useChargesData();
 
   // Calculate chart heights based on mode - memoized to prevent recalculation
@@ -225,7 +226,8 @@ export default function BYDStatsAnalyzer() {
 
   // Google Sync Hook - Connect to Context Settings
   // Note: googleSync expects setSettings. updateSettings is compatible.
-  const googleSync = useGoogleSync(rawTrips, setRawTrips, settings, updateSettings);
+  // Also syncs charges data to cloud
+  const googleSync = useGoogleSync(rawTrips, setRawTrips, settings, updateSettings, charges, replaceCharges);
 
 
   // All trips view states

--- a/src/hooks/useChargesData.js
+++ b/src/hooks/useChargesData.js
@@ -158,6 +158,20 @@ const useChargesData = () => {
         logger.info('All charges cleared');
     }, []);
 
+    /**
+     * Replace all charges with a new array (for cloud sync)
+     * @param {Array} newCharges - Array of charge objects
+     */
+    const replaceCharges = useCallback((newCharges) => {
+        if (!Array.isArray(newCharges)) {
+            logger.error('replaceCharges: expected array, got:', typeof newCharges);
+            return;
+        }
+        const sorted = [...newCharges].sort((a, b) => b.timestamp - a.timestamp);
+        setCharges(sorted);
+        logger.info(`Charges replaced with ${newCharges.length} items`);
+    }, []);
+
     // Calculate summary statistics
     const summary = useMemo(() => {
         if (charges.length === 0) return null;
@@ -182,6 +196,7 @@ const useChargesData = () => {
         deleteCharge,
         getChargeById,
         clearCharges,
+        replaceCharges,
         summary
     };
 };


### PR DESCRIPTION
Previously, only trips and settings were being synchronized to Google Drive, causing imported charging data to remain local-only and not sync between devices.

Changes:
- Added replaceCharges method to useChargesData hook for cloud sync updates
- Modified googleDrive.js to handle charges in download, upload, and merge operations
- Updated useGoogleSync.js to accept and sync charges data alongside trips and settings
- Connected charges data to cloud sync in App.jsx

Charges are now merged by ID (or timestamp fallback) during sync, ensuring all charging records are preserved and synchronized across devices.

Fixes synchronization of:
- Charging session records (imported or manually added)
- Trip data (already working)
- App settings including charger types (already working)