### PR TITLE
fix: prioritize local settings over cloud settings during sync

### DIFF
--- a/src/services/googleDrive.js
+++ b/src/services/googleDrive.js
@@ -186,8 +186,8 @@ export const googleDriveService = {
     const mergedTrips = Array.from(tripMap.values()).sort((a, b) => (a.date || '').localeCompare(b.date || ''));
 
     // 2. Merge Settings
-    // Strategy: Remote settings overlay local settings if they exist.
-    const mergedSettings = { ...localData.settings, ...remoteData.settings };
+    // Strategy: Local settings have priority. Remote settings fill in missing values.
+    const mergedSettings = { ...remoteData.settings, ...localData.settings };
 
     // 3. Merge Charges (Union by id, or timestamp if id not present)
     const localCharges = (localData && Array.isArray(localData.charges)) ? localData.charges : [];


### PR DESCRIPTION
Previously, cloud settings would overwrite local settings during merge, causing user modifications to be lost when syncing (e.g., changing battery capacity from 80.25 to 82.5 would revert back to 80.25).

Changed merge strategy to:
- Local settings have priority (any locally set value is preserved)
- Cloud settings only fill in missing local values
- Ensures user's local modifications persist across syncs

This fix maintains the correct "fresh login" behavior where cloud settings are loaded when no local data exists.