### PR TITLE
fix: move useMemo before early return to follow React Hooks rules

### DIFF
--- a/src/components/modals/SettingsModal.jsx
+++ b/src/components/modals/SettingsModal.jsx
@@ -23,9 +23,7 @@ import GoogleSyncSettings from '../settings/GoogleSyncSettings';
 const SettingsModal = ({ isOpen, onClose, settings, onSettingsChange, googleSync, charges = [] }) => {
     const { t, i18n } = useTranslation();
 
-    if (!isOpen) return null;
-
-    // Calculate average electricity price from charges
+    // Calculate average electricity price from charges (must be before early return)
     const calculatedPrice = useMemo(() => {
         if (!charges || charges.length === 0) return 0;
         const totalCost = charges.reduce((sum, c) => sum + (c.totalCost || 0), 0);
@@ -33,6 +31,8 @@ const SettingsModal = ({ isOpen, onClose, settings, onSettingsChange, googleSync
         if (totalKwh === 0) return 0;
         return totalCost / totalKwh;
     }, [charges]);
+
+    if (!isOpen) return null;
 
     const handleLanguageChange = (langCode) => {
         i18n.changeLanguage(langCode);


### PR DESCRIPTION
Fixed React error #310 by moving useMemo hook before the early return statement. React Hooks must be called in the same order on every render and cannot be placed after conditional returns.

Root cause:
The useMemo hook was being called AFTER the early return (if (!isOpen)), which violated React's Rules of Hooks. This caused the hook to not be called consistently across renders, triggering error #310.

Solution:
Moved useMemo calculation before the early return so hooks are always called in the same order, regardless of whether the modal is open.

React Hooks Rules:
- ✅ Hooks must be at the top level
- ✅ Hooks must be called in the same order every render
- ❌ Cannot call hooks after conditional returns

This was the actual root cause of the Settings modal crash.